### PR TITLE
Update transforms.conf

### DIFF
--- a/Splunk_TA_paloalto/default/transforms.conf
+++ b/Splunk_TA_paloalto/default/transforms.conf
@@ -37,7 +37,7 @@ FORMAT = sourcetype::pan:userid
 
 [pan_globalprotect]
 DEST_KEY = MetaData:Sourcetype
-REGEX = ^[^,]+,[^,]+,[^,]+,GLOBALPROTECT, 
+REGEX = ^[^,]+,[^,]+,[^,]+,GLOBALPROTECT,
 FORMAT = sourcetype::pan:globalprotect
 
 [pan_traps4]


### PR DESCRIPTION
Removed whitespace at the end of the regex for GlobalProtect sourcetype renaming.

## Description

Whitespace at the end of the GlobalProtect sourcetype renaming regex is causing the regex to fail and not identify the proper events to re-sourcetype.

## Motivation and Context

Fixes the re-sourcetyping of new GlobalProtect logs to their proper sourcetype.

## How Has This Been Tested?

Tested in a local environment for proper sourcetype renaming of the GlobalProtect logs.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
