### PR TITLE
fix(addon): Add virus eventtype to malware CIM

### DIFF
--- a/Splunk_TA_paloalto/default/eventtypes.conf
+++ b/Splunk_TA_paloalto/default/eventtypes.conf
@@ -41,6 +41,10 @@ search = sourcetype=pan_threat OR sourcetype=pan:threat AND log_subtype = "url"
 search = sourcetype=pan_threat OR sourcetype=pan:threat AND log_subtype = "data" 
 #tags = web 
 
+[pan_virus]
+search = (sourcetype=pan_threat OR sourcetype=pan:threat) AND (log_subtype = "virus" OR log_subtype = "wildfire-virus")
+#tags = malware attack
+
 [pan_spyware]
 search = sourcetype=pan_threat OR sourcetype=pan:threat AND log_subtype = "spyware" 
 #tags = ids attack

--- a/Splunk_TA_paloalto/default/tags.conf
+++ b/Splunk_TA_paloalto/default/tags.conf
@@ -36,6 +36,10 @@ filter = enabled
 web = enabled
 proxy = enabled
 
+[eventtype=pan_virus]
+malware = enabled
+attack = enabled
+
 [eventtype=pan_spyware]
 ids = enabled
 attack = enabled


### PR DESCRIPTION
# Description

Add a new pan_virus eventtype and mapped it to the malware CIM similar
to the pan_wildfire eventtype. This eventtype includes 'virus' and
'wildfire-virus' events.

Closes #114

## Motivation and Context

virus and wildfire-virus logs are not in the CIM.

## How Has This Been Tested?

Tested locally

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
