### PR TITLE
fix(app/addon): Fix background color of logo

### DIFF
--- a/Splunk_TA_paloalto/default/data/ui/nav/default.xml
+++ b/Splunk_TA_paloalto/default/data/ui/nav/default.xml
@@ -1,5 +1,5 @@
-<nav search_view="search" color="#3c6188">
-<view name="inputs" default="true" />
-<view name="configuration"/>
-<view name="search" label="Search"/>
+<nav search_view="search">
+  <view name="inputs" default="true" />
+  <view name="configuration"/>
+  <view name="search" label="Search"/>
 </nav>

--- a/Splunk_TA_paloalto/default/data/ui/nav/default.xml
+++ b/Splunk_TA_paloalto/default/data/ui/nav/default.xml
@@ -1,4 +1,4 @@
-<nav search_view="search">
+<nav search_view="search" color="#FFFFFF">
   <view name="inputs" default="true" />
   <view name="configuration"/>
   <view name="search" label="Search"/>

--- a/SplunkforPaloAltoNetworks/default/data/ui/nav/default.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/nav/default.xml
@@ -1,4 +1,4 @@
-<nav search_view="search">
+<nav search_view="search" color="#FFFFFF">
 
   <collection label="Palo Alto Networks">
     <a href="/app/Splunk_TA_paloalto">Configuration</a>

--- a/SplunkforPaloAltoNetworks/default/data/ui/nav/default.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/nav/default.xml
@@ -1,4 +1,4 @@
-<nav search_view="search" color="#004f82">
+<nav search_view="search">
 
   <collection label="Palo Alto Networks">
     <a href="/app/Splunk_TA_paloalto">Configuration</a>


### PR DESCRIPTION
## Description

The Palo Alto Networks Logo is a transparent PNG. Remove the blue shade behind the logo. 

As of Splunk 7.1. the color attribute for the navigation no longer changes the background. Instead it changes the the underline bar of the selected page. 

Splunk uses the color attribute to as a background color for the logo.



## Motivation and Context

#140 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

![Screen Shot 2020-08-24 at 3 29 37 PM](https://user-images.githubusercontent.com/1534709/91103282-fd85cb00-e61f-11ea-940e-dcadb0b6a3f6.png)

## Types of changes

<!--- What types of changes does your code introduce? -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
