### PR TITLE
Remove the 'state_change_requires_restart' flag for the TA

### DIFF
--- a/Splunk_TA_paloalto/default/app.conf
+++ b/Splunk_TA_paloalto/default/app.conf
@@ -1,5 +1,4 @@
 [install]
-state_change_requires_restart = true
 is_configured = false
 state = enabled
 build = 261908669


### PR DESCRIPTION
## Description

Remove the 'state_change_requires_restart' flag in app.conf for the TA

## Motivation and Context

This flag is marked as true which is forcing a restart at the install time, this blocks for the TA to be SSAI compatible.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
