### PR TITLE
Add inputs to app.manifest tasks to make TA SSAI

### DIFF
--- a/Splunk_TA_paloalto/app.manifest
+++ b/Splunk_TA_paloalto/app.manifest
@@ -39,7 +39,11 @@
     }
   },
   "dependencies": {},
-  "tasks": [],
+  "tasks": [
+    "autofocus_export",
+    "aperture",
+    "minemeld_feed"
+  ]
   "inputGroups": {},
   "incompatibleApps": {},
   "platformRequirements": {

--- a/Splunk_TA_paloalto/bin/lib/pandevice/pandevice/userid.py
+++ b/Splunk_TA_paloalto/bin/lib/pandevice/pandevice/userid.py
@@ -661,7 +661,7 @@ class UserId(object):
         # Find the tags section for this specific user.
         entries = ru.findall('./entry')
         for entry in entries:
-            if entry.attrib['name'] == user:
+            if entry.attrib['user'] == user:
                 te = entry.find('./tag')
                 break
         else:
@@ -705,7 +705,7 @@ class UserId(object):
         # Find the tags section for this specific user.
         entries = uu.findall('./entry')
         for entry in entries:
-            if entry.attrib['name'] == user:
+            if entry.attrib['user'] == user:
                 break
         else:
             entry = ET.SubElement(uu, 'entry', {'user': user, })

--- a/SplunkforPaloAltoNetworks/bin/lib/pandevice/pandevice/userid.py
+++ b/SplunkforPaloAltoNetworks/bin/lib/pandevice/pandevice/userid.py
@@ -661,7 +661,7 @@ class UserId(object):
         # Find the tags section for this specific user.
         entries = ru.findall('./entry')
         for entry in entries:
-            if entry.attrib['name'] == user:
+            if entry.attrib['user'] == user:
                 te = entry.find('./tag')
                 break
         else:
@@ -705,7 +705,7 @@ class UserId(object):
         # Find the tags section for this specific user.
         entries = uu.findall('./entry')
         for entry in entries:
-            if entry.attrib['name'] == user:
+            if entry.attrib['user'] == user:
                 break
         else:
             entry = ET.SubElement(uu, 'entry', {'user': user, })


### PR DESCRIPTION
## Description

Add inputs to app.manifest tasks to make TA SSAI

## Motivation and Context

When the Palo Alto TA is installed via SSAI, the inputs are stripped purged on SH by default. For the inputs to not be stripped, they need to be added to "tasks" in the app.manifest of the TA.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
