### PR TITLE
fix(app): Simplify converting 'No results found' to '0' to fix infini…

### DIFF
--- a/SplunkforPaloAltoNetworks/default/data/ui/views/data_model_audit.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/data_model_audit.xml
@@ -1,12 +1,5 @@
 <dashboard>
   <label>Data Model Audit</label>
-  <search id="tokensetter">
-    <query>| makeresults count=0</query>
-    <done>
-      <set token="results-1">0</set>
-      <set token="results-2">0</set>
-    </done>
-  </search>
   <row>
     <panel>
       <title>Logs Indexed - 24 Hours</title>
@@ -80,17 +73,9 @@
     <panel>
       <single>
         <search>
-          <query>| `pan_tstats` dc(log.serial_number) AS count FROM `fw_node(log)` GROUPBY _time | append [| makeresults count=$results-1$ | eval count=0]</query>
+          <query>| `pan_tstats` dc(log.serial_number) AS count FROM `fw_node(log)` GROUPBY _time | appendpipe [stats count | where count==0]</query>
           <earliest>-24h@h</earliest>
           <latest>now</latest>
-          <done>
-            <condition match="'job.resultCount' == 0">
-              <set token="results-1">1</set>
-            </condition>
-            <condition match="'job.resultCount' != 0 AND 'results-1' == 1">
-              <set token="results-1">0</set>
-            </condition>
-          </done>
         </search>
         <option name="colorBy">trend</option>
         <option name="colorMode">none</option>
@@ -109,17 +94,9 @@
     <panel>
       <single>
         <search>
-          <query>| `pan_tstats` dc(log.src) AS count FROM `ep_node(log)` GROUPBY _time | append [| makeresults count=$results-2$ | eval count=0]</query>
+          <query>| `pan_tstats` dc(log.src) AS count FROM `ep_node(log)` GROUPBY _time | appendpipe [stats count | where count==0]</query>
           <earliest>-24h@h</earliest>
           <latest>now</latest>
-          <done>
-            <condition match="'job.resultCount' == 0">
-              <set token="results-2">1</set>
-            </condition>
-            <condition match="'job.resultCount' != 0 AND 'results-2' == 1">
-              <set token="results-2">0</set>
-            </condition>
-          </done>
         </search>
         <option name="colorBy">trend</option>
         <option name="colorMode">none</option>

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/incident_feed.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/incident_feed.xml
@@ -1,15 +1,5 @@
 <form stylesheet="tooltip.css" script="tooltip.js">
   <label>All Incidents</label>
-  <search id="tokensetter">
-    <query>| makeresults count=0</query>
-    <done>
-      <set token="results-1">0</set>
-      <set token="results-2">0</set>
-      <set token="results-3">0</set>
-      <set token="results-4">0</set>
-      <set token="results-5">0</set>
-    </done>
-  </search>
   <search id="basesearch">
     <query>| tstats summariesonly=t prestats=t latest(_time), values(log.log_subtype), values(log.severity), values(log.app), values(log.user), values(log.threat_name), values(log.file_name), values(log.file_hash), values(log.url), values(log.dest_name), count FROM datamodel="pan_firewall" WHERE (nodename="log.threat" OR nodename="log.wildfire.malicious") $sourcetype$ $client_ip$ $server_ip$ $log_subtype$ $severity$ $action$ GROUPBY sourcetype `session` log.direction log.action
 | tstats summariesonly=t prestats=t append=t latest(_time), values(log.log_subtype), values(log.severity), values(log.threat_name), values(log.user), count FROM datamodel="pan_firewall" WHERE nodename="log.correlation" $sourcetype$ $client_ip$ $server_ip$ $log_subtype$ $severity$ $action$ GROUPBY sourcetype log.serial_number log.log_subtype log.client_ip log.action
@@ -159,17 +149,9 @@
     <panel>
       <single>
         <search>
-          <query>| tstats summariesonly=t count FROM datamodel="pan_firewall" WHERE nodename="log.correlation" GROUPBY _time span=1h | append [| makeresults count=$results-1$ | eval count=0]</query>
+          <query>| tstats summariesonly=t count FROM datamodel="pan_firewall" WHERE nodename="log.correlation" GROUPBY _time span=1h | appendpipe [stats count | where count==0]</query>
           <earliest>-24h@h</earliest>
           <latest>now</latest>
-          <done>
-            <condition match="'job.resultCount' == 0">
-              <set token="results-1">1</set>
-            </condition>
-            <condition match="'job.resultCount' != 0 AND 'results-1' == 1">
-              <set token="results-1">0</set>
-            </condition>
-          </done>
         </search>
         <option name="colorBy">trend</option>
         <option name="drilldown">all</option>
@@ -181,17 +163,9 @@
       </single>
       <single>
         <search>
-          <query>| tstats summariesonly=t count FROM datamodel="pan_firewall" WHERE nodename="log.threat" GROUPBY _time span=1h `session` | timechart span=1h count | append [| makeresults count=$results-2$ | eval count=0]</query>
+          <query>| tstats summariesonly=t count FROM datamodel="pan_firewall" WHERE nodename="log.threat" GROUPBY _time span=1h `session` | timechart span=1h count | appendpipe [stats count | where count==0]</query>
           <earliest>-24h@h</earliest>
           <latest>now</latest>
-          <done>
-            <condition match="'job.resultCount' == 0">
-              <set token="results-2">1</set>
-            </condition>
-            <condition match="'job.resultCount' != 0 AND 'results-2' == 1">
-              <set token="results-2">0</set>
-            </condition>
-          </done>
         </search>
         <option name="colorBy">trend</option>
         <option name="drilldown">all</option>
@@ -203,17 +177,9 @@
       </single>
       <single>
         <search>
-          <query>| tstats summariesonly=t count FROM datamodel="pan_traps" WHERE nodename="log.attacks" GROUPBY _time span=1h | append [| makeresults count=$results-3$ | eval count=0]</query>
+          <query>| tstats summariesonly=t count FROM datamodel="pan_traps" WHERE nodename="log.attacks" GROUPBY _time span=1h | appendpipe [stats count | where count==0]</query>
           <earliest>-24h@h</earliest>
           <latest>now</latest>
-          <done>
-            <condition match="'job.resultCount' == 0">
-              <set token="results-3">1</set>
-            </condition>
-            <condition match="'job.resultCount' != 0 AND 'results-3' == 1">
-              <set token="results-3">0</set>
-            </condition>
-          </done>
         </search>
         <option name="colorBy">trend</option>
         <option name="drilldown">all</option>
@@ -228,17 +194,9 @@
       </single>
       <single>
         <search>
-          <query>| tstats summariesonly=t count FROM datamodel="pan_aperture" WHERE nodename="log.incident" GROUPBY _time span=1h | append [| makeresults count=$results-4$ | eval count=0]</query>
+          <query>| tstats summariesonly=t count FROM datamodel="pan_aperture" WHERE nodename="log.incident" GROUPBY _time span=1h | appendpipe [stats count | where count==0]</query>
           <earliest>-24h@h</earliest>
           <latest>now</latest>
-          <done>
-            <condition match="'job.resultCount' == 0">
-              <set token="results-4">1</set>
-            </condition>
-            <condition match="'job.resultCount' != 0 AND 'results-4' == 1">
-              <set token="results-4">0</set>
-            </condition>
-          </done>
         </search>
         <option name="colorBy">trend</option>
         <option name="drilldown">all</option>
@@ -253,17 +211,9 @@
       </single>
       <single>
         <search>
-          <query>| tstats summariesonly=t count FROM datamodel="pan_firewall" WHERE nodename="log.wildfire.malicious" GROUPBY _time span=1h | append [| makeresults count=$results-5$ | eval count=0]</query>
+          <query>| tstats summariesonly=t count FROM datamodel="pan_firewall" WHERE nodename="log.wildfire.malicious" GROUPBY _time span=1h | appendpipe [stats count | where count==0]</query>
           <earliest>-24h@h</earliest>
           <latest>now</latest>
-          <done>
-            <condition match="'job.resultCount' == 0">
-              <set token="results-5">1</set>
-            </condition>
-            <condition match="'job.resultCount' != 0 AND 'results-5' == 1">
-              <set token="results-5">0</set>
-            </condition>
-          </done>
         </search>
         <option name="colorBy">trend</option>
         <option name="drilldown">all</option>
@@ -349,7 +299,6 @@
   <row>
     <panel depends="$debug$">
       <html>
-        <p>results-1: $results-1$</p>
         <p>time.earliest: $time.earliest$</p>
         <p>time.latest: $time.latest$</p>
         <p>timediff: $timediff$</p>


### PR DESCRIPTION
## Description

In two of the PA dashboards, a Splunk dashboard work-around is used to display a "0" in single value visualizations instead of "No results found." The workaround works by checking the result count of the single value visualization search. If it is zero, then set the search output to 0 (instead of No results found). If the result is non-zero, do nothing.

This fancy token manipulation works great until and including Splunk v.8.0.8. In Splunk 8.1.0, this manipulation no longer works. Because the token is used in the search and is also set after the search, the visualization is sent into an endless loop of setting the token and therefore rerunning the search which resets the token. I have confirmed this by using the Splunk Dashboards Example "token debugger" to display the tokens in real-time. The tokens switch back and forth between 1 and 0. While this is not mentioned in the Splunk release notes, I don't believe this is a Splunk-side bug but rather an unfortunate unmentioned change. I would expect a search to rerun if a token inside the search is updated, and this is standard Splunk behavior in all other cases.

The fix is to use a simpler workaround. It is possible to display "0" instead of "No results found" without using tokens at all. That's all that this PR does.

## Motivation and Context

This PR fixes #163.

## How Has This Been Tested?

Only the two modified dashboards can be affected.
This was tested by running positive and negative searches with the new `| appendpipe ...` at the end. In the negative case, the results only display a count of 0. In the positive case, the appended count of 0 is hidden (because the base search is non-zero).
This was tested on Splunk 8.0.8 and 8.1.0 on Windows and Splunk 8.1.2 on CentOS. I did not test in 7.x, but I know that this fix functions the same way in those versions.
I spent awhile trying to test using the provided Docker config but was unable to get it working. 

## Screenshots (if appropriate)



## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ n/a ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ n/a ] I have added tests to cover my changes if appropriate.
- [ unsure ] All new and existing tests passed.
