### PR TITLE
fix(addon): Parse GP and Decryption logs w/ pan:firewall

### DIFF
--- a/Splunk_TA_paloalto/default/props.conf
+++ b/Splunk_TA_paloalto/default/props.conf
@@ -31,7 +31,7 @@ pulldown_type = true
 SHOULD_LINEMERGE = false
 TIME_PREFIX = ^(?:[^,]*,){6}
 MAX_TIMESTAMP_LOOKAHEAD = 32
-TRANSFORMS-sourcetype = pan_threat, pan_traffic, pan_system, pan_config, pan_hipmatch, pan_correlation, pan_userid, pan_traps4
+TRANSFORMS-sourcetype = pan_threat, pan_traffic, pan_system, pan_config, pan_hipmatch, pan_correlation, pan_userid, pan_globalprotect, pan_decryption
 
 # Adjusts PAN-OS 6.1.0 threat logs to revised 6.1.1+ format where
 # the reportid field is at the end.


### PR DESCRIPTION
`pan:log` sourcetype was parsing GP and Decryption logs, but
`pan:firewall` sourcetype was not.

Fixes #168