### PR TITLE
fix(addon): Add fields for GlobalProtect logs

### DIFF
--- a/Splunk_TA_paloalto/default/transforms.conf
+++ b/Splunk_TA_paloalto/default/transforms.conf
@@ -103,7 +103,7 @@ FIELDS = "future_use1","receive_time","serial_number","type","log_subtype","vers
 # GlobalProtect extraction for PAN-OS 9.1.1+
 [extract_globalprotect]
 DELIMS = ","
-FIELDS = "future_use1","receive_time","serial_number","type","future_use2","version","time_generated","vsys","event_id","stage","auth_method","tunnel_type","src_user","src_region","machine_name","public_ip","public_ipv6","private_ip","private_ip","host_id","serial_number","client_ver","client_os","client_os_ver","repeat_count","reason","error","opaque","status","location","login_duration","connect_method","error_code","portal","sequence_number","action_flags",
+FIELDS = "future_use1","receive_time","serial_number","type","future_use2","version","time_generated","vsys","event_id","stage","auth_method","tunnel_type","src_user","src_region","machine_name","public_ip","public_ipv6","private_ip","private_ip","host_id","serial_number","client_ver","client_os","client_os_ver","repeat_count","reason","error","opaque","status","location","login_duration","connect_method","error_code","portal","sequence_number","action_flags","event_time","selection_type","response_time","priority","attempted_gateways","gateway","devicegroup_level1","devicegroup_level2","devicegroup_level3","devicegroup_level4","vsys_name","dvc_name","vsys_id"
 
 [extract_traps_analytics]
 DELIMS = ","


### PR DESCRIPTION
## Description

Adds a few fields for GP logs that are coming to PAN-OS and Cortex Data Lake