### PR TITLE
Update fwcloud user eval

### DIFF
--- a/Splunk_TA_paloalto/default/props.conf
+++ b/Splunk_TA_paloalto/default/props.conf
@@ -87,7 +87,7 @@ FIELDALIAS-fwcloud_threat = ThreatID as threat
 FIELDALIAS-fwcloud_threat_name = ThreatName as threat_name 
 FIELDALIAS-fwcloud_transport = Protocol as transport
 FIELDALIAS-fwcloud_type = LogType as type
-EVAL-user = coalesce(src_user,dest_user,recipient,sender,"unknown")
+EVAL-user = case(src_user!="null",'src_user',dest_user!="null",'dest_user',recipient!="null",'recipient',sender!="null",'sender',true(),"unknown")
 FIELDALIAS-fwcloud_url = URL as url
 FIELDALIAS-fwcloud_vendor_action = Action as vendor_action
 FIELDALIAS-fwcloud_verdict = Verdict as verdict


### PR DESCRIPTION
## Description

modify EVAL-user under the pan:firewall_cloud stanza of props.conf to use case instead of coalesce to account for fields containing the string "null"

## Motivation and Context

The current user eval coalesces fields which can contain a value of "null" rather than actually being null. This causes the user field to erroneously evaluate to "null" despite valid user information being present in other fields. 

## How Has This Been Tested?

Tested with Cortex Data Lake HTTP logging

## Types of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
