### PR TITLE
Change simple XML to use JQuery 3.5

### DIFF
--- a/SplunkforPaloAltoNetworks/default/data/ui/views/cortex_xdr_incidents.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/cortex_xdr_incidents.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>Cortex XDR Incidents</label>
   <search id="basesearch">
     <query>sourcetype="pan:xdr_incident" $incident_id$ $severity$ $status$ | eventstats latest(incident_id) by _time | fields _time starred incident_id severity score description hosts{} status assigned_user_pretty_name incident_sources{} xdr_url</query>

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/data_model_audit.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/data_model_audit.xml
@@ -1,4 +1,4 @@
-<dashboard>
+<dashboard version="1.1">
   <label>Data Model Audit</label>
   <row>
     <panel>

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/email_security.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/email_security.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>Email Security</label>
   <search id="basesearch">
     <query>| tstats summariesonly=t values(sourcetype) AS sourcetype, values(log.log_subtype) AS log.log_subtype,

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/file_activity.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/file_activity.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>File Activity</label>
   <description></description>
   <search id="basesearch">

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/firewall_configuration.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/firewall_configuration.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>Firewall Configuration</label>
   <fieldset autoRun="true" submitButton="true">
     <input type="time" searchWhenChanged="true">

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/firewall_system.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/firewall_system.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>Firewall System</label>
   <fieldset autoRun="true" submitButton="true">
     <input type="time" searchWhenChanged="true">

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/globalprotect.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/globalprotect.xml
@@ -1,4 +1,4 @@
-<form script="tooltip.js" stylesheet="tooltip.css">
+<form version="1.1" script="tooltip.js" stylesheet="tooltip.css">
   <label>GlobalProtect</label>
   <row id="tooltip_row">
     <html>

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/iot_activity.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/iot_activity.xml
@@ -1,4 +1,4 @@
-<dashboard>
+<dashboard version="1.1">
   <label>IoT Activity</label>
   <row>
     <panel>

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/iot_security.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/iot_security.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>IoT Security</label>
   <fieldset autoRun="true" submitButton="true">
     <input type="time" searchWhenChanged="true" token="time">

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/malware.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/malware.xml
@@ -1,4 +1,4 @@
-<form script="tooltip.js" stylesheet="tooltip.css">
+<form version="1.1" script="tooltip.js" stylesheet="tooltip.css">
   <label>Malware</label>
   <search id="basesearch">
     <query>| tstats summariesonly=t latest(_time) AS _time, values(log.log_subtype) AS log.log_subtype, values(log.severity) AS log.severity, values(log.app) AS log.app, values(log.user) AS log.user, values(log.threat_name) AS log.threat_name, values(log.file_name) AS log.file_name, count FROM datamodel="pan_firewall" WHERE nodename="log.threat" OR (nodename="log.wildfire" AND nodename!="log.wildfire.benign") $log_subtype$ $severity$ $serial$ $vsys$ GROUPBY sourcetype log.serial_number log.session_id log.client_ip log.server_ip log.direction log.action

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/network_security.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/network_security.xml
@@ -1,4 +1,4 @@
-<form script="tooltip.js" stylesheet="tooltip.css">
+<form version="1.1" script="tooltip.js" stylesheet="tooltip.css">
   <label>Network Security</label>
   <search id="basesearch">
     <query>| tstats summariesonly=t values(log.log_subtype) AS log.log_subtype, values(log.severity) AS log.severity, values(log.app) AS log.app, values(log.user) AS log.user, values(log.threat_name) AS log.threat_name, values(log.file_name) AS log.file_name, count FROM datamodel="pan_firewall" WHERE nodename="log.threat" OR (nodename="log.wildfire.malicious") OR nodename="log.data" $log_subtype$ $severity$ $app$ $dest_ip$ $serial$ $threat_name$ $vsys$ GROUPBY _time sourcetype log.serial_number log.session_id log.client_ip log.server_ip log.direction log.action log.src_zone log.dest_zone | rename log.* AS *

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/realtime_event_feed.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/realtime_event_feed.xml
@@ -1,4 +1,4 @@
-<dashboard script="tooltip.js" stylesheet="tooltip.css">
+<dashboard version="1.1" script="tooltip.js" stylesheet="tooltip.css">
   <label>Realtime Event Feed</label>
   <description>Real-time 5 minute window</description>
   <search id="baseSearch">

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/saas_activity.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/saas_activity.xml
@@ -1,4 +1,4 @@
-<form script="tooltip.js" stylesheet="tooltip.css">
+<form version="1.1" script="tooltip.js" stylesheet="tooltip.css">
   <label>SaaS Activity</label>
   <description></description>
   <search id="basesearch">

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/saas_security.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/saas_security.xml
@@ -1,4 +1,4 @@
-<form script="tooltip.js" stylesheet="tooltip.css">
+<form version="1.1" script="tooltip.js" stylesheet="tooltip.css">
   <label>SaaS Security</label>
   <description></description>
   <search id="basesearch">

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/threat_intelligence.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/threat_intelligence.xml
@@ -1,4 +1,4 @@
-<form script="tooltip.js" stylesheet="tooltip.css">
+<form version="1.1" script="tooltip.js" stylesheet="tooltip.css">
   <label>Threat Intelligence</label>
   <row id="tooltip_row">
     <html>

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/user_behavior.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/user_behavior.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>User Behavior</label>
   <search id="basesearch">
     <query>| tstats summariesonly=t latest(_time) AS _time, values(log.log_subtype) AS log.log_subtype, values(log.http_category) AS log.http_category, values(log.app:is_saas) AS log.app:is_saas, values(log.app:default_ports) AS log.app:default_ports, values(log.app) AS log.app, values(log.user) AS log.user, values(log.file_name) AS log.file_name, values(log.file_hash) AS log.file_hash, values(log.url) AS log.url, values(log.dest_name) AS log.dest_name, values(log.dest_port) AS log.dest_port, values(log.severity) AS log.severity, values(log.bytes_in) AS log.bytes_in, values(log.bytes_out) AS log.bytes_out count FROM datamodel="pan_firewall" WHERE (nodename="log.traffic" OR nodename="log.url" OR nodename="log.data") $src_ip$ $dest_ip$ $dest_name$ $log_subtype$ $app$ $category$ "$user|s$" $vsys$ $serial$ GROUPBY sourcetype log.serial_number log.session_id log.client_ip log.server_ip log.src_ip

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/web_activity.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/web_activity.xml
@@ -1,4 +1,4 @@
-<form>
+<form version="1.1">
   <label>Web Activity</label>
   <search id="basesearch">
     <query>| tstats  values(log.flags) AS log.flags, count FROM datamodel=pan_firewall WHERE nodename="log.url" $serial$ $vsys$ $src_ip$ $dest_name$ "$user|s$" $app$ $content$ $category$ $action$ GROUPBY _time log.dest_name log.app:category log.app log.action log.content_type log.vendor_action | rename log.* AS * </query>

--- a/SplunkforPaloAltoNetworks/default/data/ui/views/wildfire_submissions.xml
+++ b/SplunkforPaloAltoNetworks/default/data/ui/views/wildfire_submissions.xml
@@ -1,4 +1,4 @@
-<form script="tooltip.js" stylesheet="tooltip.css">
+<form version="1.1" script="tooltip.js" stylesheet="tooltip.css">
   <label>WildFire Submissions</label>
   <search id="basesearch">
     <query>| `pan_tstats` count FROM `node(log.wildfire)` $vsys$ $serial$ $src_ip$ $dest_ip$ "$user|s$" $src_location$ $file_name$ $file_type$ $app$ groupby _time log.rule log.src_ip log.dest_ip log.verdict log.file_name log.file_type log.user log.app log.file_hash log.src_location| rename log.* AS *</query>


### PR DESCRIPTION
## Description

Update dasheboards to use JQuery 3.5 by adding version="1.1" to root node of each dashboard.

## Motivation and Context

Splunk 8.2.2 requires dashboards to use JQuery 3.5

## How Has This Been Tested?

Tested on prem Splunk Enterprise 8.2.2

## Screenshots (if appropriate)



## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Performance

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
