### PR TITLE
Fixed string_typing 'tuple' object is not callable when parsing threats

### DIFF
--- a/SplunkforPaloAltoNetworks/bin/panContentPack.py
+++ b/SplunkforPaloAltoNetworks/bin/panContentPack.py
@@ -166,7 +166,8 @@ def parse_threats(threats_xml):
             raise e
         # convert all out of unicode
         for key in a:
-            a[key] = string_types(a[key])
+            logger.debug(key + ': ' + a[key])
+            a[key] = str(a[key])
         csv_threats.append(a)
     logger.info("Found %s threats" % len(csv_threats))
     return csv_threats


### PR DESCRIPTION
## Description

Was getting same error parsing threats and apps. Implemented fix for parsing threats just like the apps parsing had been fixed.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
This change fixes an error when parsing threats.

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
In the production environment, of course!

<!--- Include details of your testing environment, and the tests you ran to -->
Splunk Enterprise Version: 8.1.2
PAN-OS 9.1.11-h3
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
