### PR TITLE
Fix common.py get_firewall_credentials

### DIFF
--- a/SplunkforPaloAltoNetworks/bin/lib/common.py
+++ b/SplunkforPaloAltoNetworks/bin/lib/common.py
@@ -71,8 +71,10 @@ APPNAME = 'Splunk_TA_paloalto'
 class NoCredentialsFound(Exception):
     pass
 
+password = ''
 
 def get_firewall_credentials(session_key):
+    global password
     """Given a splunk session_key returns a clear text user name
     and password from a splunk password container"""
     try:
@@ -94,7 +96,7 @@ def get_firewall_credentials(session_key):
             username = accounts[i]['username']
 
     for i, c in list(entities.items()):
-        if c['username'] == 'Firewall``splunk_cred_sep``1':
+        if c['username'] == 'firewall``splunk_cred_sep``1':
             logger.debug('Match found for firewall credentials')
             clear_password = json.loads(c['clear_password'])
             password = clear_password['password']


### PR DESCRIPTION
## Description

common.py was throwing several errors.  The first was a local variable 'password' referenced before assignment.  To resolve this, I defined the password variable before the get_firewall_credentials and added the global password statement.

Once this was resolved, I received the message that no user or password were defined for the searchcommand.  This wasn't accurate, but I found that the function was looking for

'Firewall``splunk_cred_sep``1'

but should have been looking for:

'firewall``splunk_cred_sep``1'

## Motivation and Context

Advanced features of the Palo Alto Networks App for Splunk will not work without these changes, as the features require authentication to the firewall with an API key.  The current implementation cannot get that API.

## How Has This Been Tested?

I tested this by running the commands found in the example for pantag and pancontentpack in our lab environment. This is on a Splunk 8.2.7.1 instance running on RHEL 7.9.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)


## Checklist

- [ ] I have updated the documentation accordingly.
- [X ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
