### PR TITLE
Fix issue with aftags cert required by Splunk Cloud certification

### DIFF
--- a/Splunk_TA_paloalto/bin/retrieveAfTags.py
+++ b/Splunk_TA_paloalto/bin/retrieveAfTags.py
@@ -146,7 +146,7 @@ def save_to_kvstore(all_tags, skey, stats):
             _uri() + '/batch_save',
             data=json.dumps(all_tags[i:i+500]),
             headers=_headers(skey),
-            verify=False)
+            verify=True)
 
 
 def _uri():


### PR DESCRIPTION
## Description

Enable Certificate Validation for AF Tag retrieval (this is a deprecated feature)

## Motivation and Context

Failing AppInspect due to certificate validation disabled. Enable validation to pass AppInspect for Splunk Cloud certification.

