### PR TITLE
ci: Change set-output to $GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Create docker version tag
         id: versiontag
         if: needs.release.result == 'success' && needs.release.outputs.new_release_published == 'true'
-        run: echo "::set-output name=versiontag::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release.outputs.new_release_version }}"
+        run: echo "versiontag=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.release.outputs.new_release_version }}" >> $GITHUB_OUTPUT
 
       - name: Login to Container registry
         uses: docker/login-action@v1

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -141,8 +141,8 @@ tar czf "${ROOT}/_build/${FILENAME}" "${APP}"
 # Set variables for GitHub Actions to pick up in subsequent steps
 if [ "$GITHUB_ACTIONS" == "true" ]; then
     log_debug "Setting GitHub Actions outputs"
-    echo ::set-output "name=path::_build/$FILENAME"
-    echo ::set-output "name=file::$FILENAME"
+    echo "path=_build/$FILENAME" >> $GITHUB_OUTPUT
+    echo "file=$FILENAME" >> $GITHUB_OUTPUT
 fi
 
 log_debug "path: _build/$FILENAME"


### PR DESCRIPTION
Required by GitHub Actions per:
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/