### PR TITLE
feat(addon): Added DHCP CIM Compliance and extractions

### DIFF
--- a/Splunk_TA_paloalto/default/eventtypes.conf
+++ b/Splunk_TA_paloalto/default/eventtypes.conf
@@ -38,6 +38,10 @@ search = sourcetype=pan_system OR sourcetype=pan:system AND log_subtype="url-fil
 search = sourcetype=pan_system OR sourcetype=pan:system description="*config cleared*" AND NOT (log_subtype IN ("routing", "ras", "vpn"))
 #tags = change
 
+[pan_dhcp]
+search = sourcetype=pan_system OR sourcetype=pan:system AND log_subtype="dhcp"
+#tags = network session dhcp
+
 [pan_threat]
 search = sourcetype=pan_threat OR sourcetype=pan:threat OR (sourcetype=pan:firewall_cloud AND LogType="THREAT") AND log_subtype != "url" log_subtype != "file"
 #tags = ids attack

--- a/Splunk_TA_paloalto/default/props.conf
+++ b/Splunk_TA_paloalto/default/props.conf
@@ -308,7 +308,7 @@ KV_MODE = none
 TIME_PREFIX = ^(?:[^,]*,){6}
 MAX_TIMESTAMP_LOOKAHEAD = 32
 
-REPORT-search = extract_system, extract_globalprotect_user, extract_globalprotect_ip, extract_globalprotect_loginip, extract_globalprotect_clientversion, extract_globalprotect_message, extract_general_user, extract_system_alert_src, extract_system_auth
+REPORT-search = extract_system, extract_globalprotect_user, extract_globalprotect_ip, extract_globalprotect_loginip, extract_globalprotect_clientversion, extract_globalprotect_message, extract_general_user, extract_system_alert_src, extract_system_auth, extract_pan_dhcp_ip, extract_pan_dhcp_dns, extract_pan_dhcp_mac
 
 FIELDALIAS-virtual_system         = vsys as virtual_system
 # Field Aliases to map specific fields to the Splunk Common Information Model - Update
@@ -318,6 +318,7 @@ FIELDALIAS-signature              = event_id as signature
 FIELDALIAS-src_user               = user as src_user
 FIELDALIAS-reason                 = description as reason
 FIELDALIAS-body                   = description as body
+FIELDALIAS-dest_nt_host           = dest_dns as dest_nt_host
 LOOKUP-vendor_info_for_pan_config = pan_vendor_info_lookup sourcetype OUTPUT vendor,product,vendor_product
 EVAL-action = case(match(description,"(?i)succeeded"),"success",match(description,"(?i)cleared"),"cleared",match(description,"(?i)GlobalProtect gateway agent message"),"success",match(description,"(?i)Failed"),"failure")
 EVAL-app = "Palo Alto Networks Firewall"

--- a/Splunk_TA_paloalto/default/tags.conf
+++ b/Splunk_TA_paloalto/default/tags.conf
@@ -107,3 +107,8 @@ alert = enabled
 
 [eventtype=pan_aperture_admin_audit]
 authentication = enabled
+
+[eventtype=pan_dhcp]
+network = enabled
+session = enabled
+dhcp = enabled

--- a/Splunk_TA_paloalto/default/transforms.conf
+++ b/Splunk_TA_paloalto/default/transforms.conf
@@ -218,6 +218,19 @@ REGEX = Client version: (?<agent_version>[^,]+)
 SOURCE_KEY =  description
 REGEX = Message: (?<agent_message>[^,]+)
 
+#### DHCP info extractions
+[extract_pan_dhcp_ip]
+SOURCE_KEY = description
+REGEX = ip (?<dest_ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
+
+[extract_pan_dhcp_dns]
+SOURCE_KEY = description
+REGEX = hostname (?<dest_dns>.+),
+
+[extract_pan_dhcp_mac]
+SOURCE_KEY = description
+REGEX = mac (?<dest_mac>[a-fA-F0-9]{2}(:[a-fA-F0-9]{2}){5})
+
 #### lookups
 
 [endpoint_actions_lookup]

--- a/Splunk_TA_paloalto/default/transforms.conf
+++ b/Splunk_TA_paloalto/default/transforms.conf
@@ -220,15 +220,12 @@ REGEX = Message: (?<agent_message>[^,]+)
 
 #### DHCP info extractions
 [extract_pan_dhcp_ip]
-SOURCE_KEY = description
 REGEX = ip (?<dest_ip>\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})
 
 [extract_pan_dhcp_dns]
-SOURCE_KEY = description
 REGEX = hostname (?<dest_dns>.+),
 
 [extract_pan_dhcp_mac]
-SOURCE_KEY = description
 REGEX = mac (?<dest_mac>[a-fA-F0-9]{2}(:[a-fA-F0-9]{2}){5})
 
 #### lookups


### PR DESCRIPTION
## Description

Added tags, event types, field extractions and aliases to extract the DHCP info from the PAN System logs

## Motivation and Context

This adds CIM compliance and usability for the PAN DHCP logs, to be used in Network_Sessions.DHCP datamodel

## How Has This Been Tested?

Tested it in a local instance of Splunk and extractions work

## Screenshots (if appropriate)

N/A

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes if appropriate.
- [X] All new and existing tests passed.
